### PR TITLE
feat: 投稿作成（new/create）を公開（バリデーション・フォーム整備／一覧導線）

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,70 +1,51 @@
 class PostsController < ApplicationController
   before_action :set_post, only: %i[ show edit update destroy ]
 
-  # GET /posts or /posts.json
   def index
-    @posts = Post.all
+    @posts = Post.all.order(created_at: :desc)
   end
 
-  # GET /posts/1 or /posts/1.json
   def show
   end
 
-  # GET /posts/new
   def new
     @post = Post.new
   end
 
-  # GET /posts/1/edit
-  def edit
-  end
-
-  # POST /posts or /posts.json
   def create
     @post = Post.new(post_params)
 
-    respond_to do |format|
-      if @post.save
-        format.html { redirect_to @post, notice: "Post was successfully created." }
-        format.json { render :show, status: :created, location: @post }
-      else
-        format.html { render :new, status: :unprocessable_entity }
-        format.json { render json: @post.errors, status: :unprocessable_entity }
-      end
+    if @post.save
+      # show ではなく一覧へ戻す（MVP段階）
+      redirect_to posts_path, notice: "投稿が作成されました！"
+    else
+      render :new, status: :unprocessable_entity
     end
   end
 
-  # PATCH/PUT /posts/1 or /posts/1.json
+  def edit
+  end
+
   def update
-    respond_to do |format|
-      if @post.update(post_params)
-        format.html { redirect_to @post, notice: "Post was successfully updated.", status: :see_other }
-        format.json { render :show, status: :ok, location: @post }
-      else
-        format.html { render :edit, status: :unprocessable_entity }
-        format.json { render json: @post.errors, status: :unprocessable_entity }
-      end
+    if @post.update(post_params)
+      redirect_to @post, notice: "投稿が更新されました。"
+    else
+      render :edit, status: :unprocessable_entity
     end
   end
 
-  # DELETE /posts/1 or /posts/1.json
   def destroy
-    @post.destroy!
-
-    respond_to do |format|
-      format.html { redirect_to posts_path, notice: "Post was successfully destroyed.", status: :see_other }
-      format.json { head :no_content }
-    end
+    @post.destroy
+    redirect_to posts_path, notice: "投稿が削除されました。"
   end
 
   private
-    # Use callbacks to share common setup or constraints between actions.
-    def set_post
-      @post = Post.find(params[:id])
-    end
 
-    # Only allow a list of trusted parameters through.
-    def post_params
-      params.require(:post).permit(:title, :situation, :content)
-    end
+  def set_post
+    @post = Post.find(params[:id])
+  end
+
+  def post_params
+    params.require(:post).permit(:title, :situation, :content)
+  end
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,2 +1,5 @@
 class Post < ApplicationRecord
+  validates :title,     presence: true, length: { maximum: 50 }
+  validates :situation, presence: true, length: { maximum: 100 }
+  validates :content,   presence: true, length: { maximum: 1000 }
 end

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -1,32 +1,50 @@
-<%= form_with(model: post) do |form| %>
-  <% if post.errors.any? %>
-    <div style="color: red">
-      <h2><%= pluralize(post.errors.count, "error") %> prohibited this post from being saved:</h2>
+<%= form_with(
+      model: post,
+      url: posts_path,          # 送信先を明示
+      method: :post,            # POST を明示
+      local: true,              # 同期送信（デバッグしやすい）
+      data: { turbo: false },   # Turboが干渉しないよう無効化
+      class: "space-y-6"
+    ) do |f| %>
 
-      <ul>
-        <% post.errors.each do |error| %>
-          <li><%= error.full_message %></li>
+  <% if post.errors.any? %>
+    <div class="mb-6 rounded-lg border border-red-200 bg-red-50 p-4">
+      <p class="font-medium text-red-800 mb-2">入力エラーがあります：</p>
+      <ul class="list-disc list-inside space-y-1 text-sm text-red-700">
+        <% post.errors.full_messages.each do |message| %>
+          <li><%= message %></li>
         <% end %>
       </ul>
     </div>
   <% end %>
 
-  <div>
-    <%= form.label :title, style: "display: block" %>
-    <%= form.text_field :title %>
-  </div>
+  <div class="space-y-4">
+    <div>
+      <%= f.label :title, "タイトル", class: "block text-sm font-medium text-gray-700 mb-1" %>
+      <%= f.text_field :title,
+            class: "w-full rounded-md border px-3 py-2 focus:border-blue-500 focus:ring-1 focus:ring-blue-500",
+            placeholder: "例：日常会話で学んだ表現" %>
+    </div>
 
-  <div>
-    <%= form.label :situation, style: "display: block" %>
-    <%= form.text_field :situation %>
-  </div>
+    <div>
+      <%= f.label :situation, "学習した場面", class: "block text-sm font-medium text-gray-700 mb-1" %>
+      <%= f.text_field :situation,
+            class: "w-full rounded-md border px-3 py-2 focus:border-blue-500 focus:ring-1 focus:ring-blue-500",
+            placeholder: "例：コンビニでの買い物" %>
+    </div>
 
-  <div>
-    <%= form.label :content, style: "display: block" %>
-    <%= form.text_area :content %>
-  </div>
+    <div>
+      <%= f.label :content, "内容・詳細", class: "block text-sm font-medium text-gray-700 mb-1" %>
+      <%= f.text_area :content, rows: 6,
+            class: "w-full rounded-md border px-3 py-2 focus:border-blue-500 focus:ring-1 focus:ring-blue-500",
+            placeholder: "学んだ表現や気づいたことを詳しく書いてください..." %>
+    </div>
 
-  <div>
-    <%= form.submit %>
+    <div class="pt-4 flex gap-3">
+      <%= f.submit "投稿する",
+            class: "rounded-md bg-blue-600 px-6 py-2 text-white font-medium hover:bg-blue-700 transition-colors" %>
+      <%= link_to "一覧に戻る", posts_path,
+            class: "rounded-md border px-6 py-2 text-gray-700 hover:bg-gray-50 transition-colors" %>
+    </div>
   </div>
 <% end %>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -5,8 +5,9 @@
       <h1 class="text-2xl font-bold">投稿一覧</h1>
       <p class="text-gray-600 text-sm">日常で出会った「生きた日本語」をみんなで共有しよう</p>
     </div>
-    <!-- 次のIssueで new を有効化するまでボタンは非表示 -->
-    <%#= link_to "新規投稿", new_post_path, class: "rounded-md bg-black text-white px-4 py-2 hover:opacity-90" %>
+
+    <!-- 新規投稿ボタン（有効化） -->
+    <%= link_to "新規投稿", new_post_path, class: "rounded-md bg-black text-white px-4 py-2 hover:opacity-90" %>
   </div>
 
   <% if @posts.any? %>
@@ -16,35 +17,36 @@
           <h3 class="font-semibold text-lg mb-2">
             <%= post.title.presence || "（タイトル未設定）" %>
           </h3>
-          
+
           <div class="space-y-2 text-sm">
             <p class="text-gray-600">
               <span class="font-medium">学習場面：</span>
               <%= post.situation.presence || "—" %>
             </p>
-            
+
             <% if post.content.present? %>
               <p class="text-gray-700 leading-relaxed">
                 <%= truncate(post.content, length: 80) %>
               </p>
             <% end %>
           </div>
-          
+
           <div class="mt-4 pt-3 border-t border-gray-100 flex justify-between items-center">
             <p class="text-xs text-gray-400">
               <%= l(post.created_at, format: :short) %>
             </p>
-            <%= link_to "Show this post", post, class: "text-blue-600 hover:text-blue-800 text-sm" %>
+            <%= link_to "詳細を見る", post, class: "text-blue-600 hover:text-blue-800 text-sm" %>
           </div>
         </article>
       <% end %>
     </div>
   <% else %>
-    <div class="rounded-lg border-2 border-dashed border-gray-200 bg-gray-50 p-12 text-center">
-      <div class="space-y-3">
-        <div class="text-gray-400 text-4xl">📝</div>
-        <h3 class="text-lg font-medium text-gray-900">まだ投稿がありません</h3>
-        <p class="text-gray-600">次のIssueで「投稿作成」機能を実装予定です。</p>
+    <div class="rounded-lg border-2 border-dashed border-gray-200 bg-gray-50 p-12 text-center space-y-4">
+      <div class="text-gray-400 text-4xl">📝</div>
+      <h3 class="text-lg font-medium text-gray-900">まだ投稿がありません</h3>
+      <p class="text-gray-600">最初の投稿を作成して、みんなで学びを共有しましょう。</p>
+      <div class="pt-2">
+        <%= link_to "新規投稿", new_post_path, class: "inline-block rounded-md bg-black text-white px-4 py-2 hover:opacity-90" %>
       </div>
     </div>
   <% end %>

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -1,11 +1,10 @@
-<% content_for :title, "New post" %>
+<% content_for :title, "新規投稿" %>
 
-<h1>New post</h1>
-
-<%= render "form", post: @post %>
-
-<br>
-
-<div>
-  <%= link_to "Back to posts", posts_path %>
+<div class="container mx-auto px-4 py-8">
+  <div class="max-w-2xl mx-auto">
+    <h1 class="text-3xl font-bold text-gray-800 mb-8">新規投稿</h1>
+    <div class="bg-white rounded-lg shadow-md p-6">
+      <%= render "form", post: @post %>
+    </div>
+  </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,13 +1,9 @@
 Rails.application.routes.draw do
-  resources :posts
   root "home#index"
-  # 投稿機能（段階的リリース）
-  resources :posts, only: [ :index ]
 
-  # ヘルスチェック用（本番環境で有用）
+  # MVP: 一覧・作成・詳細のみ公開（編集/削除は後続Issue）
+  resources :posts, only: [ :index, :new, :create, :show ]
+
+  # ヘルスチェック
   get "up" => "rails/health#show", as: :rails_health_check
-
-  # 将来的なルーティング（コメントアウト）
-  # resources :users, only: [:new, :create, :show]
-  # resources :groups, only: [:index, :show, :new, :create]
 end


### PR DESCRIPTION
### 目的
MVPの流れに沿って投稿作成機能を公開。詳細は維持、編集/削除は後続Issue。

### 変更点
- ルーティング: posts を index/new/create/show のみに限定
- モデル: title/situation/content の必須 + 文字数上限
- コントローラ: create成功時は一覧へリダイレクト（notice表示）
- ビュー: _form/new をTailwindで整備、indexに「新規投稿」ボタン
- フォームは送信先・メソッドを明示し Turbo を無効化（POST安定化）
- RuboCop/Brakeman 実行済み

### 動作確認
- /posts/new → 入力 → 送信 → /posts でカード追加＆「投稿が作成されました！」を確認
- /posts/:id で詳細表示（h1あり）