### PR TITLE
fix: showをMVP用に簡素化（edit/destroyリンク削除)

### DIFF
--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -1,10 +1,26 @@
-<p style="color: green"><%= notice %></p>
+<% content_for :title, "投稿詳細" %>
 
-<%= render @post %>
+<section class="max-w-3xl mx-auto space-y-6">
+  <h1 class="text-2xl font-bold">投稿詳細</h1>
 
-<div>
-  <%= link_to "Edit this post", edit_post_path(@post) %> |
-  <%= link_to "Back to posts", posts_path %>
+  <article class="rounded-lg border bg-white p-6 space-y-4">
+    <div>
+      <h2 class="text-xl font-semibold"><%= @post.title %></h2>
+      <p class="text-sm text-gray-500 mt-1">
+        <%= l(@post.created_at, format: :short) %>
+      </p>
+    </div>
 
-  <%= button_to "Destroy this post", @post, method: :delete %>
-</div>
+    <div class="text-sm text-gray-700">
+      <p class="mb-1"><span class="font-medium">学習場面：</span><%= @post.situation %></p>
+      <div class="mt-3 leading-relaxed whitespace-pre-wrap">
+        <%= simple_format(@post.content) %>
+      </div>
+    </div>
+  </article>
+
+  <div>
+    <%= link_to "一覧に戻る", posts_path,
+          class: "inline-flex items-center gap-2 rounded-md border border-gray-300 px-4 py-2 text-sm text-gray-700 bg-white hover:bg-gray-50" %>
+  </div>
+</section>


### PR DESCRIPTION
## 目的
- 本番で /posts/:id アクセス時に発生していた 500 エラーを解消する。
- MVP段階では「編集・削除」を未公開のため、詳細画面を最小表示にする。

## 背景（不具合の原因）
- ルーティングを `index/new/create/show` のみに限定している一方、
  `app/views/posts/show.html.erb` が scaffold デフォルトのままで
  `edit_post_path(@post)` と `button_to ... method: :delete` を呼び出していた。
- 本番ログにも `undefined method 'edit_post_path'` が多数出力されており、これが 500 の直接原因。

## 変更内容
- `app/views/posts/show.html.erb`
  - 編集・削除リンクを削除
  - `render @post` をやめ、タイトル／学習場面／内容のみをシンプルに表示
  - 一覧への戻り導線を追加
- `public/favicon.ico`
  - 404を回避するためダミーのfaviconを追加（後日差し替え予定）

## 動作確認
- ローカル
  - `/posts/1` で 500 にならないこと
  - タイトル／学習場面／内容が表示され、「一覧に戻る」で `/posts` に遷移すること
- 本番(Render)
  - デプロイ後 `/posts/:id` で 500 が発生しないことを確認

## 影響範囲
- 投稿詳細画面（show）のみ
- 編集・削除はまだ公開していないため影響なし

## デプロイ後の確認項目
- [ ] `/posts/new` → 作成 → `/posts` に表示される
- [ ] `/posts/:id` に直接アクセスしても正常表示
- [ ] favicon の 404 が出ない（ログが静か）

## 備考（運用メモ）
- Render に Post-deploy コマンドの設定を推奨：
  - `bundle exec rails db:migrate`
- Build Command 例：
  - `bundle install && yarn install --frozen-lockfile && bundle exec rails assets:precompile`

## テスト・Lint
- `bin/rubocop -A` 実行済み（警告なし）
- `bin/brakeman -q` 実行済み（新規 High なし）
