### PR TITLE
style: 投稿詳細ページをMVP向けに読みやすく整形（Tailwind）

### DIFF
--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -1,26 +1,40 @@
 <% content_for :title, "投稿詳細" %>
 
-<section class="max-w-3xl mx-auto space-y-6">
-  <h1 class="text-2xl font-bold">投稿詳細</h1>
-
-  <article class="rounded-lg border bg-white p-6 space-y-4">
+<section class="mx-auto max-w-3xl space-y-8">
+  <!-- 上部ヘッダ -->
+  <header class="flex items-start justify-between gap-4">
     <div>
-      <h2 class="text-xl font-semibold"><%= @post.title %></h2>
-      <p class="text-sm text-gray-500 mt-1">
-        <%= l(@post.created_at, format: :short) %>
+      <h1 class="text-2xl md:text-3xl font-bold tracking-tight"><%= @post.title %></h1>
+      <p class="mt-2 text-sm text-gray-500">
+        <span class="inline-flex items-center gap-1">
+          <span class="font-medium text-gray-600">学習場面：</span>
+          <%= @post.situation %>
+        </span>
+        <span class="mx-2 text-gray-300">|</span>
+        <time datetime="<%= @post.created_at.iso8601 %>">
+          <%= l(@post.created_at, format: :long) %>
+        </time>
       </p>
     </div>
 
-    <div class="text-sm text-gray-700">
-      <p class="mb-1"><span class="font-medium">学習場面：</span><%= @post.situation %></p>
-      <div class="mt-3 leading-relaxed whitespace-pre-wrap">
-        <%= simple_format(@post.content) %>
-      </div>
+    <div class="shrink-0">
+      <%= link_to "一覧に戻る", posts_path,
+        class: "inline-flex items-center rounded-md border border-gray-300 px-4 py-2 text-sm text-gray-700 bg-white hover:bg-gray-50" %>
+    </div>
+  </header>
+
+  <!-- 本文カード -->
+  <article class="rounded-2xl border bg-white p-6 md:p-8 shadow-sm">
+    <div class="prose max-w-none leading-relaxed text-gray-800">
+      <%= simple_format(@post.content) %>
     </div>
   </article>
 
-  <div>
-    <%= link_to "一覧に戻る", posts_path,
-          class: "inline-flex items-center gap-2 rounded-md border border-gray-300 px-4 py-2 text-sm text-gray-700 bg-white hover:bg-gray-50" %>
+  <!-- MVP後に編集/削除を入れる場所（今は非表示のメモ） -->
+  <%# 
+  <div class="flex justify-end gap-3">
+    <%= link_to "編集", edit_post_path(@post), class: "btn" %>
+    <%= button_to "削除", @post, method: :delete, data: { confirm: "削除しますか？" }, class: "btn-danger" %>
   </div>
+  %>
 </section>


### PR DESCRIPTION
### 目的
MVP向けに投稿詳細の可読性を改善。

### 変更
- show.html.erb をカードレイアウトに刷新
- 学習場面/投稿日をメタ情報として上部表示
- 一覧へ戻る導線の明確化
- 編集/削除は後続Issueのためコメント化のまま

### 動作確認
- /posts/:id が500にならず、整ったレイアウトで表示される
