### PR TITLE
投稿の編集・削除機能を実装（MVP）

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,12 +1,11 @@
 class PostsController < ApplicationController
-  before_action :set_post, only: %i[ show edit update destroy ]
+  before_action :set_post, only: %i[show edit update destroy]
 
   def index
-    @posts = Post.all.order(created_at: :desc)
+    @posts = Post.order(created_at: :desc)
   end
 
-  def show
-  end
+  def show; end
 
   def new
     @post = Post.new
@@ -14,21 +13,18 @@ class PostsController < ApplicationController
 
   def create
     @post = Post.new(post_params)
-
     if @post.save
-      # show ではなく一覧へ戻す（MVP段階）
       redirect_to posts_path, notice: "投稿が作成されました！"
     else
       render :new, status: :unprocessable_entity
     end
   end
 
-  def edit
-  end
+  def edit; end
 
   def update
     if @post.update(post_params)
-      redirect_to @post, notice: "投稿が更新されました。"
+      redirect_to @post, notice: "投稿を更新しました。"
     else
       render :edit, status: :unprocessable_entity
     end

--- a/app/views/posts/edit.html.erb
+++ b/app/views/posts/edit.html.erb
@@ -1,12 +1,16 @@
-<% content_for :title, "Editing post" %>
+<% content_for :title, "投稿を編集" %>
 
-<h1>Editing post</h1>
+<div class="container mx-auto px-4 py-8">
+  <div class="max-w-2xl mx-auto">
+    <h1 class="text-3xl font-bold text-gray-800 mb-8">投稿を編集</h1>
 
-<%= render "form", post: @post %>
+    <div class="bg-white rounded-lg shadow-md p-6">
+      <%= render "form", post: @post %>
+    </div>
 
-<br>
-
-<div>
-  <%= link_to "Show this post", @post %> |
-  <%= link_to "Back to posts", posts_path %>
+    <div class="mt-6 flex items-center gap-4">
+      <%= link_to "詳細へ戻る", @post, class: "rounded-md border px-4 py-2 text-sm text-gray-700 hover:bg-gray-50" %>
+      <%= link_to "一覧に戻る", posts_path, class: "text-sm text-gray-500 hover:text-gray-700" %>
+    </div>
+  </div>
 </div>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -1,40 +1,35 @@
 <% content_for :title, "投稿詳細" %>
 
 <section class="mx-auto max-w-3xl space-y-8">
-  <!-- 上部ヘッダ -->
   <header class="flex items-start justify-between gap-4">
     <div>
       <h1 class="text-2xl md:text-3xl font-bold tracking-tight"><%= @post.title %></h1>
       <p class="mt-2 text-sm text-gray-500">
-        <span class="inline-flex items-center gap-1">
-          <span class="font-medium text-gray-600">学習場面：</span>
-          <%= @post.situation %>
-        </span>
+        <span class="font-medium text-gray-600">学習場面：</span><%= @post.situation %>
         <span class="mx-2 text-gray-300">|</span>
-        <time datetime="<%= @post.created_at.iso8601 %>">
-          <%= l(@post.created_at, format: :long) %>
-        </time>
+        <time datetime="<%= @post.created_at.iso8601 %>"><%= l(@post.created_at, format: :long) %></time>
       </p>
     </div>
 
-    <div class="shrink-0">
+    <div class="shrink-0 flex gap-2">
+      <%= link_to "編集", edit_post_path(@post),
+            class: "inline-flex items-center rounded-md border border-gray-300 px-4 py-2 text-sm text-gray-700 bg-white hover:bg-gray-50" %>
+
+      <%# Turbo を無効化して確実に DELETE を送る %>
+      <%= button_to "削除", post_path(@post),
+            method: :delete,
+            data: { turbo_confirm: "本当に削除しますか？" },
+            form: { data: { turbo: false } },
+            class: "inline-flex items-center rounded-md bg-red-600 px-4 py-2 text-sm text-white hover:bg-red-700" %>
+
       <%= link_to "一覧に戻る", posts_path,
-        class: "inline-flex items-center rounded-md border border-gray-300 px-4 py-2 text-sm text-gray-700 bg-white hover:bg-gray-50" %>
+            class: "inline-flex items-center rounded-md border border-gray-300 px-4 py-2 text-sm text-gray-700 bg-white hover:bg-gray-50" %>
     </div>
   </header>
 
-  <!-- 本文カード -->
   <article class="rounded-2xl border bg-white p-6 md:p-8 shadow-sm">
     <div class="prose max-w-none leading-relaxed text-gray-800">
       <%= simple_format(@post.content) %>
     </div>
   </article>
-
-  <!-- MVP後に編集/削除を入れる場所（今は非表示のメモ） -->
-  <%# 
-  <div class="flex justify-end gap-3">
-    <%= link_to "編集", edit_post_path(@post), class: "btn" %>
-    <%= button_to "削除", @post, method: :delete, data: { confirm: "削除しますか？" }, class: "btn-danger" %>
-  </div>
-  %>
 </section>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,9 +1,8 @@
 Rails.application.routes.draw do
   root "home#index"
 
-  # MVP: 一覧・作成・詳細のみ公開（編集/削除は後続Issue）
-  resources :posts, only: [ :index, :new, :create, :show ]
+  # 投稿は MVP で CRUD まで利用
+  resources :posts, only: [ :index, :new, :create, :show, :edit, :update, :destroy ]
 
-  # ヘルスチェック
   get "up" => "rails/health#show", as: :rails_health_check
 end


### PR DESCRIPTION
## 概要
- 投稿の編集（edit/update）と削除（destroy）を実装
- 削除は button_to + method: :delete、Turbo無効化で確実にサーバーに届くよう対応
- 投稿詳細（show）画面のUI微修正
- 日本語のフラッシュメッセージ整備

## 変更ファイル（主要）
- app/controllers/posts_controller.rb
- app/views/posts/show.html.erb

## 動作確認
- ローカル：作成→詳細→編集→削除 すべて正常。フラッシュ表示OK。
- ルーティング：DELETE /posts/:id が有効

## 影響範囲
- 投稿CRUD（認証なしのMVP動線のみ）

## 関連Issue
- #X 「投稿編集」
- #Y 「投稿削除」
