### PR TITLE
feat(posts): 一覧のタイトルを詳細リンクに変更

### DIFF
--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -14,8 +14,11 @@
     <div class="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
       <% @posts.order(created_at: :desc).each do |post| %>
         <article class="rounded-lg border bg-white p-4 hover:shadow-md transition-shadow">
+          <!-- ★タイトルをリンク化 -->
           <h3 class="font-semibold text-lg mb-2">
-            <%= post.title.presence || "（タイトル未設定）" %>
+            <%= link_to (post.title.presence || "（タイトル未設定）"),
+                        post,
+                        class: "hover:underline hover:text-blue-700" %>
           </h3>
 
           <div class="space-y-2 text-sm">


### PR DESCRIPTION
## 概要
投稿一覧ページ（posts#index）のカードタイトルをクリックで詳細（posts#show）に遷移できるようにしました。
ユーザーが直感的に詳細へアクセスできる導線を改善します。

## 変更点
- app/views/posts/index.html.erb
  - タイトル部を link_to でラップ（hover時の装飾付き）

### 修正前
<h3 class="font-semibold text-lg mb-2">
  <%= post.title.presence || "（タイトル未設定）" %>
</h3>

### 修正後
<h3 class="font-semibold text-lg mb-2">
  <%= link_to (post.title.presence || "（タイトル未設定）"),
              post,
              class: "hover:underline hover:text-blue-700" %>
</h3>

## 動作確認
- [x] 一覧表示が崩れない
- [x] タイトルクリックで該当の詳細ページに遷移する
- [x] Rubocop パス
- [x] ローカル（http://localhost:3000/posts）で確認

## 備考
Render は Auto Deploy 設定のため、マージ後に本番で動作確認します。
