### PR TITLE
fix(posts): 新規/編集フォームの送信先を明示し、投稿ボタンが効かない問題を修正

### DIFF
--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -1,9 +1,9 @@
 <%= form_with(
       model: post,
-      url: posts_path,          # 送信先を明示
-      method: :post,            # POST を明示
-      local: true,              # 同期送信（デバッグしやすい）
-      data: { turbo: false },   # Turboが干渉しないよう無効化
+      url:  post.persisted? ? post_path(post) : posts_path,            # ← 新規/編集でURLを明示
+      method: post.persisted? ? :patch : :post,                        # ← 新規=POST / 編集=PATCH
+      local: true,                                                     # ← 同期送信
+      data: { turbo: false },                                          # ← Turbo無効（送信の確実化）
       class: "space-y-6"
     ) do |f| %>
 
@@ -41,10 +41,14 @@
     </div>
 
     <div class="pt-4 flex gap-3">
-      <%= f.submit "投稿する",
+      <%= f.submit (post.persisted? ? "更新する" : "投稿する"),
             class: "rounded-md bg-blue-600 px-6 py-2 text-white font-medium hover:bg-blue-700 transition-colors" %>
-      <%= link_to "一覧に戻る", posts_path,
-            class: "rounded-md border px-6 py-2 text-gray-700 hover:bg-gray-50 transition-colors" %>
+
+      <% if post.persisted? %>
+        <%= link_to "詳細へ戻る", post, class: "rounded-md border px-6 py-2 text-gray-700 hover:bg-gray-50 transition-colors" %>
+      <% else %>
+        <%= link_to "一覧に戻る", posts_path, class: "rounded-md border px-6 py-2 text-gray-700 hover:bg-gray-50 transition-colors" %>
+      <% end %>
     </div>
   </div>
 <% end %>


### PR DESCRIPTION
概要

posts/_form.html.erb のフォームが常に POST /posts を向いていたため、
編集画面でも新規作成扱いになったり、新規投稿が送信されないことがありました。

新規/編集で URL と HTTP メソッドを明示的に切り替え、確実に送信されるように修正。

送信は local: true + data: { turbo: false } で Turbo の干渉を避けています。

変更内容

app/views/posts/_form.html.erb

url: を post.persisted? ? post_path(post) : posts_path に変更

method: を post.persisted? ? :patch : :post に変更

local: true, data: { turbo: false } を付与

送信ボタンの文言を 新規=「投稿する」/ 編集=「更新する」 に自動切替

戻り導線を 新規=一覧へ / 編集=詳細へ に自動切替