### PR TITLE
feat: 日本語ロケール&JST対応、削除ボタンを本番で非表示

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,6 +36,8 @@ gem "bootsnap", require: false
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 # gem "image_processing", "~> 1.2"
 
+gem "rails-i18n", "~> 7.0"
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri windows ], require: "debug/prelude"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -213,6 +213,9 @@ GEM
     rails-html-sanitizer (1.6.2)
       loofah (~> 2.21)
       nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
+    rails-i18n (7.0.10)
+      i18n (>= 0.7, < 2)
+      railties (>= 6.0.0, < 8)
     railties (7.2.2.2)
       actionpack (= 7.2.2.2)
       activesupport (= 7.2.2.2)
@@ -325,6 +328,7 @@ DEPENDENCIES
   pg (~> 1.1)
   puma (>= 5.0)
   rails (~> 7.2.2, >= 7.2.2.2)
+  rails-i18n (~> 7.0)
   rubocop-rails-omakase
   selenium-webdriver
   sprockets-rails

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,5 +1,6 @@
 class PostsController < ApplicationController
   before_action :set_post, only: %i[show edit update destroy]
+  before_action :protect_destroy_in_production, only: :destroy  # ← 追加
 
   def index
     @posts = Post.order(created_at: :desc)
@@ -43,5 +44,11 @@ class PostsController < ApplicationController
 
   def post_params
     params.require(:post).permit(:title, :situation, :content)
+  end
+
+  # ▼ 本番では削除を一時的に無効化（MVP措置）
+  def protect_destroy_in_production
+    return unless Rails.env.production?
+    redirect_to @post, alert: "MVP段階の本番環境では削除を無効化しています。ログイン実装後に本人のみ削除可にします。"
   end
 end

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -15,12 +15,12 @@
       <%= link_to "編集", edit_post_path(@post),
             class: "inline-flex items-center rounded-md border border-gray-300 px-4 py-2 text-sm text-gray-700 bg-white hover:bg-gray-50" %>
 
-      <%# Turbo を無効化して確実に DELETE を送る %>
-      <%= button_to "削除", post_path(@post),
-            method: :delete,
-            data: { turbo_confirm: "本当に削除しますか？" },
-            form: { data: { turbo: false } },
-            class: "inline-flex items-center rounded-md bg-red-600 px-4 py-2 text-sm text-white hover:bg-red-700" %>
+      <% unless Rails.env.production? %>
+        <%= button_to "削除", post_path(@post),
+              method: :delete,
+              form: { data: { turbo_confirm: "本当に削除しますか？" } },
+              class: "inline-flex items-center rounded-md bg-red-600 px-4 py-2 text-sm text-white hover:bg-red-700" %>
+      <% end %>
 
       <%= link_to "一覧に戻る", posts_path,
             class: "inline-flex items-center rounded-md border border-gray-300 px-4 py-2 text-sm text-gray-700 bg-white hover:bg-gray-50" %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,27 +1,21 @@
+# config/application.rb
 require_relative "boot"
-
 require "rails/all"
 
-# Require the gems listed in Gemfile, including any gems
-# you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
-module Myapp
+module WeLearnTogether
   class Application < Rails::Application
-    # Initialize configuration defaults for originally generated Rails version.
+    # Rails 7 系の既定設定を読み込む（8.0は不可）
     config.load_defaults 7.2
 
-    # Please, add to the `ignore` list any other `lib` subdirectories that do
-    # not contain `.rb` files, or that should not be reloaded or eager loaded.
-    # Common ones are `templates`, `generators`, or `middleware`, for example.
-    config.autoload_lib(ignore: %w[assets tasks])
+    # 表示は日本時間、DB保存はUTCのまま
+    config.time_zone = "Tokyo"
+    config.active_record.default_timezone = :utc
 
-    # Configuration for the application, engines, and railties goes here.
-    #
-    # These settings can be overridden in specific environments using the files
-    # in config/environments, which are processed later.
-    #
-    # config.time_zone = "Central Time (US & Canada)"
-    # config.eager_load_paths << Rails.root.join("extras")
+    # 既定ロケールを日本語に
+    config.i18n.default_locale = :ja
+    # （任意）読み込みロケールの拡張：locales配下のymlを全部読む
+    config.i18n.load_path += Dir[Rails.root.join("config", "locales", "**", "*.{rb,yml}")]
   end
 end

--- a/config/ja.yml
+++ b/config/ja.yml
@@ -1,0 +1,8 @@
+# config/locales/ja.yml
+ja:
+  time:
+    formats:
+      long: "%Y年%m月%d日 %H:%M"
+  date:
+    formats:
+      long: "%Y年%m月%d日"


### PR DESCRIPTION
## 目的
- 講師レビュー指摘の「時刻がUTC表示」「誰でも削除可能に見える」点に対応

## 変更点
- rails-i18n導入、config.i18n.default_locale = :ja
- 表示タイムゾーンを JST に（config.time_zone = 'Tokyo'）
- DB保存はUTCのまま（config.active_record.default_timezone = :utc）
- posts#show の削除ボタンを本番では非表示（unless Rails.env.production?）

## 確認方法
- ローカルで `/posts` と `/posts/:id` を確認
  - 日付が日本語 & JST（例: `10/05 18:51` / `2025年10月05日 18:30`）で表示される
  - 詳細画面で削除ボタンが表示される（開発環境）
- 本番（Render）で `/posts/:id` を開く
  - 削除ボタンが表示されない（本番環境）

## 補足
- 認可は次イテレーションで実装予定（ログイン後に本人のみ編集/削除可能に）
